### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Absolutely, yes. It's intended to be tongue-in-cheek, but also I couldn't think 
     Search for 'Gherkin Auto-Complete Plus'
 #### Mac OSX
     cd ~/Library/Application\ Support/Sublime\ Text\ 3/Packages
-    git clone git://https://github.com/austincrft/sublime-gherkin-auto-complete-plus.git "Gherkin Auto-Complete Plus"
+    git clone https://github.com/austincrft/sublime-gherkin-auto-complete-plus.git "Gherkin Auto-Complete Plus"
 #### Linux
     cd ~/.config/sublime-text-3/Installed\ Packages
-    git clone git://https://github.com/austincrft/sublime-gherkin-auto-complete-plus.git "Gherkin Auto-Complete Plus"
+    git clone https://github.com/austincrft/sublime-gherkin-auto-complete-plus.git "Gherkin Auto-Complete Plus"
 #### Windows
     cd Users/<user>/AppData/Roaming/Sublime\ Text\ 3/Installed\ Packages/
-    git clone git://https://github.com/austincrft/sublime-gherkin-auto-complete-plus.git "Gherkin Auto-Complete Plus"
+    git clone https://github.com/austincrft/sublime-gherkin-auto-complete-plus.git "Gherkin Auto-Complete Plus"
 
 
 ## Credits


### PR DESCRIPTION
The clone URL is invalid, I was getting this error when attempting to clone:

`fatal: Unable to look up https (port 9418) (nodename nor servname provided, or not known)`

I was able to find the fix [here](http://stackoverflow.com/questions/24276026/npm-install-git-problems).

I am using a Mac, I assume this would also work on Windows and Linux.
