### PR TITLE
Updated settings.py

### DIFF
--- a/gherkin_auto_complete_plus/utilities/settings.py
+++ b/gherkin_auto_complete_plus/utilities/settings.py
@@ -22,9 +22,12 @@ def get_feature_directories():
     settings = _get_package_settings()
     feature_directories = settings.get('feature_file_directories', default=[])
     
-    feature_directories_absolute_path = settings.get('feature_file_directories_absolute', default=[])
+    feature_directories_paths = []
+    for folder in feature_directories:   
+        if os.path.exists(folder):
+            feature_directories_paths.append(folder)
+            feature_directories.remove(folder)
     
-    feature_directories_paths = feature_directories_absolute_path
     for project_folder in sublime.active_window().folders():        
         folders = os.listdir(project_folder)
         for folder in folders:

--- a/gherkin_auto_complete_plus/utilities/settings.py
+++ b/gherkin_auto_complete_plus/utilities/settings.py
@@ -25,16 +25,13 @@ def get_feature_directories():
     feature_directories_absolute_path = settings.get('feature_file_directories_absolute', default=[])
     
     feature_directories_paths = feature_directories_absolute_path
+    for project_folder in sublime.active_window().folders():        
+        folders = os.listdir(project_folder)
+        for folder in folders:
+          if any(folder in features_path for features_path in feature_directories):
+            full_folder_path = os.path.join(project_folder, folder)
+            feature_directories_paths.append(full_folder_path + "/*")
 
-    project_data = sublime.active_window().project_data()
-    project_folder = project_data['folders'][0]['path']    
-    
-    folders = os.listdir(project_folder)
-    for folder in folders:
-      if any(folder in features_path for features_path in feature_directories):
-        full_folder_path = os.path.join(project_folder, folder)
-        feature_directories_paths.append(full_folder_path + "/*")
-        
     return feature_directories_paths
 
 

--- a/gherkin_auto_complete_plus/utilities/settings.py
+++ b/gherkin_auto_complete_plus/utilities/settings.py
@@ -1,5 +1,5 @@
 import logging
-
+import os, re
 import sublime
 
 
@@ -21,7 +21,19 @@ def get_feature_directories():
     """
     settings = _get_package_settings()
     feature_directories = settings.get('feature_file_directories', default=[])
-    return feature_directories
+    
+    feature_directories_paths = []
+
+    project_data = sublime.active_window().project_data()
+    project_folder = project_data['folders'][0]['path']    
+    
+    folders = os.listdir(project_folder)
+    for folder in folders:
+      if any(folder in features_path for features_path in feature_directories):
+        full_folder_path = os.path.join(project_folder, folder)
+        feature_directories_paths.append(full_folder_path + "/*")
+        
+    return feature_directories_paths
 
 
 def ignore_open_directories():

--- a/gherkin_auto_complete_plus/utilities/settings.py
+++ b/gherkin_auto_complete_plus/utilities/settings.py
@@ -22,7 +22,9 @@ def get_feature_directories():
     settings = _get_package_settings()
     feature_directories = settings.get('feature_file_directories', default=[])
     
-    feature_directories_paths = []
+    feature_directories_absolute_path = settings.get('feature_file_directories_absolute', default=[])
+    
+    feature_directories_paths = feature_directories_absolute_path
 
     project_data = sublime.active_window().project_data()
     project_folder = project_data['folders'][0]['path']    


### PR DESCRIPTION
Updated settings.py to use relative paths not absolute paths from feature_file_directories array. This allows me to have the following settings: 

```
{
    "feature_file_directories":
    [
      "features"
    ]
}
```

that give me the ability to work on different projects while not changing the settings file. Before I would have to change the absolute path inside the settings file when i switched projects.
